### PR TITLE
feat: add Angular Schematics extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ These are all the extensions I also recommend using for my [free Angular trainin
  
  * [Move TS](https://marketplace.visualstudio.com/items?itemName=stringham.move-ts) - this is a great extension to help you refactor and re-organize some files and components in the project. It automatically fixes the imports on the file (or component folder) that is being moved and also files that are importing the component you are moving. To use it: right-click on a file or folder in the Project Explorer pane and select 'Move TypeScript'.
 
+ * [Angular Schematics](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics) - this extension allows you to launch Angular schematics (CLI commands) from files Explorer (right-click) or Command Palette.
+
 ### Code Analysis
 
 * [TSLint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint) - linter for the TypeScript language, help fixing error in TS code.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "eg2.tslint",
         "christian-kohler.path-intellisense",
         "rbbit.typescript-hero",
-        "stringham.move-ts"
+        "stringham.move-ts",
+        "cyrilletuzi.angular-schematics"
     ]
 }


### PR DESCRIPTION
Hi @loiane,

I did a GUI tool for Angular schematics / CLI commands for VS Code. It was done to improve productivity, so I think it would really fit in this Angular extension pack.

You can test the extension here: [https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics)

If you think it's a good extension, this PR adds it to your extension pack. Otherwise, I would appreciate feedback. Thanks.